### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,8 @@ jobs:
   prepare-changelog:
     name: Prepare Changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/FrancoStino/commit-ai-jetbrains-plugin/security/code-scanning/4](https://github.com/FrancoStino/commit-ai-jetbrains-plugin/security/code-scanning/4)

To fix the problem, we should specify minimal permissions for the `prepare-changelog` job by adding a `permissions` block under it. Based on the steps used in this job (checkout, uploading artifacts, generating files locally), it only needs read access to the repository contents. Therefore, in `.github/workflows/build.yml`, add:

```yaml
permissions:
  contents: read
```

just below the line `175: name: Prepare Changelog`. This restricts the GITHUB_TOKEN access for this job to read-only, following the principle of least privilege and resolving the CodeQL finding.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
