### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   # Prepare the environment and build the plugin


### PR DESCRIPTION
Potential fix for [https://github.com/FrancoStino/commit-ai-jetbrains-plugin/security/code-scanning/3](https://github.com/FrancoStino/commit-ai-jetbrains-plugin/security/code-scanning/3)

To fix the problem, add a top-level `permissions` block to the workflow file `.github/workflows/build.yml` before the `jobs:` key (or give each job its own block where stricter/looser permissions are needed). Since the jobs shown only need to read repository contents (fetch sources, run tests, upload artifacts), set `contents: read` as the minimal required permission. If a specific job needs to write to issues or pull-requests, add a tailored `permissions` block to that job. For now, add the following at the root level (after `on:` and before `jobs:`):

```yaml
permissions:
  contents: read
```

This ensures the GITHUB_TOKEN cannot perform write operations unless specifically permitted. No additional libraries or method definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
