### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@
 ## JBIJPPTPL
 
 name: Build
+permissions:
+  contents: read
 on:
   # Trigger the workflow on pushes to only the 'master' branch (this avoids duplicate checks being run e.g., for dependabot pull requests)
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FrancoStino/commit-ai-jetbrains-plugin/security/code-scanning/2](https://github.com/FrancoStino/commit-ai-jetbrains-plugin/security/code-scanning/2)

To fix the issue, we should add an explicit `permissions` block to restrict the GITHUB_TOKEN to the least privilege necessary. The easiest way—since none of the steps appear to require write access except perhaps in separate jobs like releases (not shown here)—is to set `permissions: contents: read` at the root of the workflow file, so all jobs inherit read-only access to repository contents. This is done by inserting the block immediately after the workflow `name:` or `on:` block (here, right after `name: Build`). If any jobs do need broader or different permissions, they can override via their own `permissions` block, but that is not required based on the information shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
