### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   # Prepare the environment and build the plugin


### PR DESCRIPTION
Potential fix for [https://github.com/FrancoStino/commit-ai-jetbrains-plugin/security/code-scanning/1](https://github.com/FrancoStino/commit-ai-jetbrains-plugin/security/code-scanning/1)

The best way to fix this problem is to add a `permissions` block that limits the GITHUB_TOKEN permissions for the workflow. This can be done at the workflow root level (affecting all jobs that do not override with their own `permissions` block), or individually in each job. For brevity and best practice, add it at the workflow root unless specific jobs require greater privileges. The strictest starting point is `contents: read`, which enables all the actions shown, unless (e.g.) any release-creating job is present (which is not shown in the excerpt). If the jobs shown (build, test, verify, and prepare-changelog) only need to read repository contents and upload artifacts, then `contents: read` is sufficient. If in the omitted `prepare-changelog` job or elsewhere you need write, you can elevate privilege for that job alone.

Therefore, insert the following block above `jobs:` (for example, after `concurrency:`):

```yaml
permissions:
  contents: read
```

No external imports or dependencies are needed; this is a change to the workflow YAML only. The edit should be at the workflow root, between the triggers (`on:`, `concurrency:`) and `jobs:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
