### PR TITLE
Update Pollinations AI endpoint and models

### DIFF
--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
@@ -18,7 +18,7 @@ object CommitAIBundle : DynamicBundle(BUNDLE) {
     val URL_BUG_REPORT = URI("https://github.com/FrancoStino/commit-ai-jetbrains-plugin/28558-commit-ai/issues")
     val URL_PROMPTS_DISCUSSION = URI("https://github.com/FrancoStino/commit-ai-jetbrains-plugin/28558-commit-ai/discussions/2")
     val URL_LLM_CLIENTS_DISCUSSION = URI("https://github.com/FrancoStino/commit-ai-jetbrains-plugin/discussions/7")
-    val URL_POLLINATIONS_AUTH = URI("https://auth.pollinations.ai/")
+    val URL_POLLINATIONS_AUTH = URI("https://enter.pollinations.ai/")
     val URL_GROQ_KEYS = URI("https://console.groq.com/keys")
     val URL_GITHUB = URI("https://github.com/FrancoStino/commit-ai-jetbrains-plugin")
     val URL_KOFI = URI("https://ko-fi.com/davideladisa")

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt
@@ -17,7 +17,7 @@ class PollinationsClientConfiguration : BaseRestLLMClientConfiguration(
 
     init {
         templatePresentation.text = "${getClientName()}: $modelId"
-        host = "https://text.pollinations.ai/openai"
+        host = "https://gen.pollinations.ai/v1"
     }
 
     @Attribute

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientService.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientService.kt
@@ -25,7 +25,7 @@ class PollinationsClientService(private val cs: CoroutineScope) : LLMClientServi
         @JvmStatic
         fun getInstance(): PollinationsClientService = service()
 
-        private val seedModels = setOf("gemini", "gemini-search", PollinationsClientConfiguration.DEFAULT_MODEL, "openai-reasoning", "evil", "unity")
+        private val seedModels = setOf("gemini", "gemini-search", PollinationsClientConfiguration.DEFAULT_MODEL)
     }
 
     override suspend fun buildChatModel(client: PollinationsClientConfiguration): ChatModel {

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientSharedState.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientSharedState.kt
@@ -22,17 +22,35 @@ class PollinationsClientSharedState : PersistentStateComponent<PollinationsClien
     }
 
     override var hosts: MutableSet<String> = mutableSetOf(
-        "https://text.pollinations.ai/openai"
+        "https://gen.pollinations.ai/v1"
     )
 
     override var modelIds: MutableSet<String> = mutableSetOf(
-        "gemini",
-        "gemini-search",
+        "openai",
+        "openai-fast",
         PollinationsClientConfiguration.DEFAULT_MODEL,
-        "openai-reasoning",
-        "bidara",
-        "evil",
-        "unity"
+        "qwen-coder",
+        "mistral",
+        "openai-audio",
+        "gemini",
+        "gemini-fast",
+        "deepseek",
+        "grok",
+        "gemini-search",
+        "chickytutor",
+        "midijourney",
+        "claude-fast",
+        "claude",
+        "claude-large",
+        "perplexity-fast",
+        "perplexity-reasoning",
+        "kimi",
+        "gemini-large",
+        "gemini-legacy",
+        "nova-fast",
+        "glm",
+        "minimax",
+        "nomnom"
     )
 
     override fun getState(): PollinationsClientSharedState = this


### PR DESCRIPTION
This change updates the Pollinations AI integration to use the new endpoints and the latest model list. The base URL has been moved to gen.pollinations.ai/v1, and the authentication link now points to enter.pollinations.ai. The list of available models has also been updated to include new additions like deepseek, grok, and claude variants, while removing deprecated ones.

Fixes #75

---
*PR created automatically by Jules for task [11507975920415250043](https://jules.google.com/task/11507975920415250043) started by @FrancoStino*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended AI model library with 20+ new supported models including OpenAI variants, Mistral, DeepSeek, Grok, Claude family, Perplexity, and others.

* **Bug Fixes**
  * Updated API endpoints and authentication infrastructure for improved service compatibility.
  * Simplified token requirements for core AI models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->