### PR TITLE
Refactor plugin retrieval method in AICommitsBundle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = com.davideladisa.commit-ai
 pluginName = Commit AI
 pluginRepositoryUrl = https://github.com/FrancoStino/commit-ai-jetbrains-plugin
-pluginVersion=1.6.7
+pluginVersion=1.6.8
 
 pluginSinceBuild = 251
 # pluginUntilBuild = 253.*

--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
@@ -2,8 +2,7 @@ package com.davideladisa.commitai
 
 import com.intellij.DynamicBundle
 import com.intellij.ide.browsers.BrowserLauncher
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import org.jetbrains.annotations.NonNls
@@ -42,7 +41,7 @@ object CommitAIBundle : DynamicBundle(BUNDLE) {
         BrowserLauncher.instance.open("https://github.com/FrancoStino/commit-ai-jetbrains-plugin")
     }
 
-    fun plugin() = PluginManagerCore.getPlugin(PluginId.getId("com.davideladisa.commit-ai"))
+    fun plugin() = PluginManager.getPluginByClass(CommitAIBundle::class.java)
 
 
 }


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/francostino/commit-ai-jetbrains-plugin/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored plugin lookup in `CommitAIBundle` to use `PluginManager.getPluginByClass(...)` for safer retrieval, and bumped the plugin version to 1.6.8.

- **Refactors**
  - Replaced `PluginManagerCore.getPlugin(PluginId.getId("com.davideladisa.commit-ai"))` with `PluginManager.getPluginByClass(CommitAIBundle::class.java)` and removed related imports.

- **Dependencies**
  - Updated pluginVersion to 1.6.8 in gradle.properties.

<sup>Written for commit 367801a371c8a703ce955e9f5bfe78255300b831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/commit-ai-jetbrains-plugin/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switches plugin descriptor lookup from the internal `PluginManagerCore.getPlugin(PluginId.getId("com.davideladisa.commit-ai"))` to the public `PluginManager.getPluginByClass(CommitAIBundle::class.java)`, removing the hardcoded plugin ID string and two internal-API imports. The version is bumped to 1.6.8.

- The return type of `plugin()` remains `IdeaPluginDescriptor?`, and the only caller (`ApplicationStartupListener`) already guards with the safe-call operator `?.version`, so no callers are impacted.
- Using `getPluginByClass` resolves the plugin via the classloader that loaded `CommitAIBundle`, which is always the plugin's own classloader in a normal JetBrains plugin deployment — making the result equivalent to the old ID-based lookup.

<h3>Confidence Score: 5/5</h3>

This is a safe, minimal refactoring with no behavioral changes — the public API replacement returns the same type and all callers are unaffected.

The change swaps an internal IntelliJ API for its public equivalent, removes a hardcoded plugin ID string, and leaves the return type and all call sites untouched. The sole caller already handles the nullable return safely. No logic is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt | Replaces PluginManagerCore.getPlugin(PluginId) with PluginManager.getPluginByClass(CommitAIBundle::class.java); removes two imports. Return type is unchanged (IdeaPluginDescriptor?), and the sole caller already uses safe-call (?.) operator. |
| gradle.properties | Version bump from 1.6.7 to 1.6.8 to accompany the refactoring change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ASL as ApplicationStartupListener
    participant CAB as CommitAIBundle
    participant PM as PluginManager

    ASL->>CAB: plugin()
    CAB->>PM: getPluginByClass(CommitAIBundle::class.java)
    PM-->>CAB: IdeaPluginDescriptor?
    CAB-->>ASL: IdeaPluginDescriptor?
    ASL->>ASL: "version = descriptor?.version"
```

<sub>Reviews (2): Last reviewed commit: ["fix: update plugin version to 1.6.8"](https://github.com/francostino/commit-ai-jetbrains-plugin/commit/367801a371c8a703ce955e9f5bfe78255300b831) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36659593)</sub>

<!-- /greptile_comment -->