### PR TITLE
fix: replace internal PluginManager.getPluginByClass with public Plug…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = com.davideladisa.commit-ai
 pluginName = Commit AI
 pluginRepositoryUrl = https://github.com/FrancoStino/commit-ai-jetbrains-plugin
-pluginVersion=1.6.8
+pluginVersion=1.6.9
 
 pluginSinceBuild = 251
 # pluginUntilBuild = 253.*

--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
@@ -2,7 +2,8 @@ package com.davideladisa.commitai
 
 import com.intellij.DynamicBundle
 import com.intellij.ide.browsers.BrowserLauncher
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import org.jetbrains.annotations.NonNls
@@ -41,7 +42,7 @@ object CommitAIBundle : DynamicBundle(BUNDLE) {
         BrowserLauncher.instance.open("https://github.com/FrancoStino/commit-ai-jetbrains-plugin")
     }
 
-    fun plugin() = PluginManager.getPluginByClass(CommitAIBundle::class.java)
+    fun plugin() = PluginManagerCore.getPlugin(PluginId.getId("com.davideladisa.commit-ai"))
 
 
 }

--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
@@ -42,7 +42,9 @@ object CommitAIBundle : DynamicBundle(BUNDLE) {
         BrowserLauncher.instance.open("https://github.com/FrancoStino/commit-ai-jetbrains-plugin")
     }
 
-    fun plugin() = PluginManagerCore.getPlugin(PluginId.getId("com.davideladisa.commit-ai"))
+    private const val PLUGIN_ID = "com.davideladisa.commit-ai"
+
+    fun plugin() = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
 
 
 }


### PR DESCRIPTION
…inManagerCore.getPlugin (develop)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced internal `PluginManager.getPluginByClass` with public `PluginManagerCore.getPlugin` using `PluginId`, and extracted the plugin ID to a `PLUGIN_ID` constant to remove internal API usage and magic strings. Bumped plugin version to 1.6.9 for compatibility with recent JetBrains IDE versions.

<sup>Written for commit 88e81f21cf3f0d172660411290547b78890e8c9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/commit-ai-jetbrains-plugin/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/francostino/commit-ai-jetbrains-plugin/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the use of the internal `PluginManager.getPluginByClass` API and replaces it with `PluginManagerCore.getPlugin(PluginId)`, while extracting the plugin ID string into a named constant. The version is bumped to 1.6.9 to accompany the fix.

- Swaps `PluginManager.getPluginByClass(CommitAIBundle::class.java)` for `PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))`, removing a class-reflection-based lookup in favour of an explicit ID lookup.
- Introduces `private const val PLUGIN_ID = \"com.davideladisa.commit-ai\"` inside the `CommitAIBundle` object; the value matches the `<id>` in `plugin.xml` and the `pluginGroup` in `gradle.properties`.
- The only call site (`ApplicationStartupListener.kt`) already uses `?.version`, so the nullable return type of `PluginManagerCore.getPlugin` is handled safely.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward internal-API swap with no behavioural impact on the running plugin.

The replacement call is functionally equivalent to the old one, the extracted constant matches the canonical plugin ID in both plugin.xml and gradle.properties, and the sole call site already guards against the nullable return. No logic paths are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt | Replaces PluginManager.getPluginByClass with PluginManagerCore.getPlugin(PluginId) and extracts the plugin ID into a private const val PLUGIN_ID; the ID matches plugin.xml, and the single call site already handles the nullable return with ?.version. |
| gradle.properties | Version bumped from 1.6.8 to 1.6.9; no other changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant L as ApplicationStartupListener
    participant B as CommitAIBundle
    participant PM as PluginManagerCore
    participant PID as PluginId

    L->>B: plugin()
    B->>PID: getId("com.davideladisa.commit-ai")
    PID-->>B: PluginId
    B->>PM: getPlugin(pluginId)
    PM-->>B: IdeaPluginDescriptor?
    B-->>L: IdeaPluginDescriptor?
    L->>L: descriptor?.version
```

<sub>Reviews (3): Last reviewed commit: ["feat: bump plugin version from 1.6.8 to ..."](https://github.com/francostino/commit-ai-jetbrains-plugin/commit/88e81f21cf3f0d172660411290547b78890e8c9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37179263)</sub>

<!-- /greptile_comment -->