### PR TITLE
fix: replace internal PluginManager.findEnabledPlugin with public Plu…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = com.davideladisa.commit-ai
 pluginName = Commit AI
 pluginRepositoryUrl = https://github.com/FrancoStino/commit-ai-jetbrains-plugin
-pluginVersion=1.6.12
+pluginVersion=1.6.13
 
 pluginSinceBuild = 251
 # pluginUntilBuild = 253.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = com.davideladisa.commit-ai
 pluginName = Commit AI
 pluginRepositoryUrl = https://github.com/FrancoStino/commit-ai-jetbrains-plugin
-pluginVersion=1.6.10
+pluginVersion=1.6.11
 
 pluginSinceBuild = 251
 # pluginUntilBuild = 253.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 pluginGroup = com.davideladisa.commit-ai
 pluginName = Commit AI
 pluginRepositoryUrl = https://github.com/FrancoStino/commit-ai-jetbrains-plugin
-pluginVersion=1.6.11
+pluginVersion=1.6.12
 
 pluginSinceBuild = 251
 # pluginUntilBuild = 253.*

--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
@@ -2,7 +2,7 @@ package com.davideladisa.commitai
 
 import com.intellij.DynamicBundle
 import com.intellij.ide.browsers.BrowserLauncher
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
@@ -44,7 +44,7 @@ object CommitAIBundle : DynamicBundle(BUNDLE) {
 
     private const val PLUGIN_ID = "com.davideladisa.commit-ai"
 
-    fun plugin() = PluginManager.getInstance().findEnabledPlugin(PluginId.getId(PLUGIN_ID))
+    fun plugin() = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
 
 
 }

--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
@@ -40,12 +40,13 @@ object CommitAIBundle : DynamicBundle(BUNDLE) {
         BrowserLauncher.instance.open("https://github.com/FrancoStino/commit-ai-jetbrains-plugin")
     }
 
-    fun pluginVersion(): String? =
+    fun pluginVersion(): String? = runCatching {
         CommitAIBundle::class.java
             .getResourceAsStream("/META-INF/plugin.xml")
             ?.use { stream ->
                 val text = stream.bufferedReader().readText()
                 Regex("<version>(.*?)</version>").find(text)?.groupValues?.get(1)
             }
+    }.getOrNull()
 
 }

--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
@@ -2,8 +2,6 @@ package com.davideladisa.commitai
 
 import com.intellij.DynamicBundle
 import com.intellij.ide.browsers.BrowserLauncher
-import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.cl.PluginAwareClassLoader
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import org.jetbrains.annotations.NonNls
@@ -42,10 +40,12 @@ object CommitAIBundle : DynamicBundle(BUNDLE) {
         BrowserLauncher.instance.open("https://github.com/FrancoStino/commit-ai-jetbrains-plugin")
     }
 
-    fun plugin(): IdeaPluginDescriptor? {
-        val cl = CommitAIBundle::class.java.classLoader
-        return (cl as? PluginAwareClassLoader)?.pluginDescriptor as? IdeaPluginDescriptor
-    }
-
+    fun pluginVersion(): String? =
+        CommitAIBundle::class.java
+            .getResourceAsStream("/META-INF/plugin.xml")
+            ?.use { stream ->
+                val text = stream.bufferedReader().readText()
+                Regex("<version>(.*?)</version>").find(text)?.groupValues?.get(1)
+            }
 
 }

--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
@@ -2,8 +2,8 @@ package com.davideladisa.commitai
 
 import com.intellij.DynamicBundle
 import com.intellij.ide.browsers.BrowserLauncher
-import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.openapi.extensions.PluginId
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.cl.PluginAwareClassLoader
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import org.jetbrains.annotations.NonNls
@@ -42,9 +42,10 @@ object CommitAIBundle : DynamicBundle(BUNDLE) {
         BrowserLauncher.instance.open("https://github.com/FrancoStino/commit-ai-jetbrains-plugin")
     }
 
-    private const val PLUGIN_ID = "com.davideladisa.commit-ai"
-
-    fun plugin() = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
+    fun plugin(): IdeaPluginDescriptor? {
+        val cl = CommitAIBundle::class.java.classLoader
+        return (cl as? PluginAwareClassLoader)?.pluginDescriptor
+    }
 
 
 }

--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt
@@ -44,7 +44,7 @@ object CommitAIBundle : DynamicBundle(BUNDLE) {
 
     fun plugin(): IdeaPluginDescriptor? {
         val cl = CommitAIBundle::class.java.classLoader
-        return (cl as? PluginAwareClassLoader)?.pluginDescriptor
+        return (cl as? PluginAwareClassLoader)?.pluginDescriptor as? IdeaPluginDescriptor
     }
 
 

--- a/src/main/kotlin/com/davideladisa/commitai/listeners/ApplicationStartupListener.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/listeners/ApplicationStartupListener.kt
@@ -15,7 +15,7 @@ class ApplicationStartupListener : ProjectActivity {
     }
     private fun showVersionNotification(project: Project) {
         val settings = AppSettings2.instance
-        val version = CommitAIBundle.plugin()?.version
+        val version = CommitAIBundle.pluginVersion()
 
         if (version == settings.lastVersion) {
             return


### PR DESCRIPTION
…ginManagerCore.getPlugin

PluginManager.findEnabledPlugin is annotated @ApiStatus.Internal and must not be used by third-party plugins. Replace it with the stable public API PluginManagerCore.getPlugin() which returns the IdeaPluginDescriptor if the plugin is installed (null otherwise).

Resolves: IntelliJ Plugin Verifier INTERNAL_API_USAGES warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed internal IntelliJ API usage by replacing `plugin()` with a safe `pluginVersion()` that reads `/META-INF/plugin.xml`. Updated the startup listener to use it and bumped `pluginVersion` to 1.6.13, resolving Plugin Verifier INTERNAL_API_USAGES and keeping cross-version compatibility.

- **Bug Fixes**
  - Removed `PluginManager`/`PluginManagerCore`/`PluginAwareClassLoader` usage.
  - Added `CommitAIBundle.pluginVersion()` that reads `<version>` from `/META-INF/plugin.xml` and wraps I/O in `runCatching` to return null on failure.
  - Updated `ApplicationStartupListener` to use the new accessor.

<sup>Written for commit 3946ff618ac4da52e9913a6f6756d28db159ca87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/commit-ai-jetbrains-plugin/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `@ApiStatus.Internal` usage of `PluginManager.findEnabledPlugin` and replaces it with a classloader-based approach that reads the `<version>` element from the bundled `/META-INF/plugin.xml`, resolving the Plugin Verifier `INTERNAL_API_USAGES` warning.

- **`AICommitsBundle`**: `plugin()` is replaced with `pluginVersion()`, which uses `runCatching` around a `getResourceAsStream` + regex parse of `plugin.xml`; all internal SDK imports are removed.
- **`ApplicationStartupListener`**: Call site updated from `plugin()?.version` to `pluginVersion()`; an existing guard (`firstTime && version != null`) prevents sending the welcome notification when the version is null, but `settings.lastVersion` is still written as null on failure, which can cause the version-change check to short-circuit permanently on subsequent startups.
- **`gradle.properties`**: Version bumped to `1.6.13`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one outstanding concern: `settings.lastVersion` can be silently overwritten to null when XML parsing fails, which permanently suppresses version notifications for affected users.

The internal API removal is correct and complete. The only risk is in `ApplicationStartupListener`: when `pluginVersion()` returns null (resource missing, regex no-match, or stream error), `settings.lastVersion` is still written as null. On the next startup, `null == null` causes an early return and the user never sees a version notification again — with no error surface to diagnose the failure. This concern was flagged in a prior review and has not yet been addressed in the current diff.

src/main/kotlin/com/davideladisa/commitai/listeners/ApplicationStartupListener.kt — the `settings.lastVersion = version` assignment on line 24 runs unconditionally, including when `version` is null.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| gradle.properties | Version bumped from 1.6.10 to 1.6.13; minor version skip is likely intentional from intermediate commits. |
| src/main/kotlin/com/davideladisa/commitai/AICommitsBundle.kt | Replaces internal `PluginManager.findEnabledPlugin` with classloader-based XML parsing; eliminates internal API usage but introduces silent failure modes when parsing returns null. |
| src/main/kotlin/com/davideladisa/commitai/listeners/ApplicationStartupListener.kt | Updated to use `pluginVersion()` instead of `plugin()?.version`; `settings.lastVersion` can be overwritten to null when version parsing fails, silently suppressing future notifications. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant IDE as IntelliJ IDE
    participant ASL as ApplicationStartupListener
    participant Bundle as CommitAIBundle
    participant JAR as /META-INF/plugin.xml
    participant Settings as AppSettings2

    IDE->>ASL: execute(project)
    ASL->>Bundle: pluginVersion()
    Bundle->>JAR: getResourceAsStream("/META-INF/plugin.xml")
    alt resource found
        JAR-->>Bundle: InputStream
        Bundle->>Bundle: readText() + Regex match
        Bundle-->>ASL: version string (e.g. "1.6.13")
    else resource not found / parse error
        Bundle-->>ASL: null (via runCatching)
    end
    ASL->>Settings: read lastVersion
    alt "version == lastVersion"
        ASL-->>IDE: return (no notification)
    else "version != lastVersion"
        ASL->>Settings: "lastVersion = version (may write null)"
        alt "firstTime && version != null"
            ASL->>IDE: sendNotification(welcome)
        end
        ASL->>ASL: "firstTime = false"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant IDE as IntelliJ IDE
    participant ASL as ApplicationStartupListener
    participant Bundle as CommitAIBundle
    participant JAR as /META-INF/plugin.xml
    participant Settings as AppSettings2

    IDE->>ASL: execute(project)
    ASL->>Bundle: pluginVersion()
    Bundle->>JAR: getResourceAsStream("/META-INF/plugin.xml")
    alt resource found
        JAR-->>Bundle: InputStream
        Bundle->>Bundle: readText() + Regex match
        Bundle-->>ASL: version string (e.g. "1.6.13")
    else resource not found / parse error
        Bundle-->>ASL: null (via runCatching)
    end
    ASL->>Settings: read lastVersion
    alt "version == lastVersion"
        ASL-->>IDE: return (no notification)
    else "version != lastVersion"
        ASL->>Settings: "lastVersion = version (may write null)"
        alt "firstTime && version != null"
            ASL->>IDE: sendNotification(welcome)
        end
        ASL->>ASL: "firstTime = false"
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/main/kotlin/com/davideladisa/commitai/listeners/ApplicationStartupListener.kt`, line 24 ([link](https://github.com/francostino/commit-ai-jetbrains-plugin/blob/5887de7cc82cecc5d04eefec45e798469cef8377/src/main/kotlin/com/davideladisa/commitai/listeners/ApplicationStartupListener.kt#L24)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`lastVersion` wiped to null when version parsing fails**

   The old `PluginManager.findEnabledPlugin` would practically never return null while the plugin was actively running (the plugin IS enabled — it's calling this code). The new `pluginVersion()` has additional failure modes: resource not found by classloader, regex mismatch if `patchPluginXml` didn't inject `<version>`, or a stream exception swallowed by `runCatching`. When any of those happen, `version` is null, `settings.lastVersion` gets overwritten to null, and on the next startup `null == null` causes an early return — permanently suppressing version notifications for that user without any error surface.

   <a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22francostino%2Fcommit-ai-jetbrains-plugin%22%20on%20the%20existing%20branch%20%22develop%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22develop%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fmain%2Fkotlin%2Fcom%2Fdavideladisa%2Fcommitai%2Flisteners%2FApplicationStartupListener.kt%0ALine%3A%2024%0A%0AComment%3A%0A**%60lastVersion%60%20wiped%20to%20null%20when%20version%20parsing%20fails**%0A%0AThe%20old%20%60PluginManager.findEnabledPlugin%60%20would%20practically%20never%20return%20null%20while%20the%20plugin%20was%20actively%20running%20%28the%20plugin%20IS%20enabled%20%E2%80%94%20it's%20calling%20this%20code%29.%20The%20new%20%60pluginVersion%28%29%60%20has%20additional%20failure%20modes%3A%20resource%20not%20found%20by%20classloader%2C%20regex%20mismatch%20if%20%60patchPluginXml%60%20didn't%20inject%20%60%3Cversion%3E%60%2C%20or%20a%20stream%20exception%20swallowed%20by%20%60runCatching%60.%20When%20any%20of%20those%20happen%2C%20%60version%60%20is%20null%2C%20%60settings.lastVersion%60%20gets%20overwritten%20to%20null%2C%20and%20on%20the%20next%20startup%20%60null%20%3D%3D%20null%60%20causes%20an%20early%20return%20%E2%80%94%20permanently%20suppressing%20version%20notifications%20for%20that%20user%20without%20any%20error%20surface.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=francostino%2Fcommit-ai-jetbrains-plugin&tid=70573&ts=1782299018&sig=004a39469100e1ca6b6ab25ece2def47ff13e7caa62b783216c9230f429ee935&pr=117&platform=github&fid=5c0eed31-b6e0-48de-99bd-4cb9d75786ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInDevin.svg?v=3"><img alt="Fix in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInDevin.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (8): Last reviewed commit: ["Update gradle.properties"](https://github.com/francostino/commit-ai-jetbrains-plugin/commit/3946ff618ac4da52e9913a6f6756d28db159ca87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39497108)</sub>

<!-- /greptile_comment -->