### PR TITLE
Improve Pollinations default and commit message parsing

### DIFF
--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsUtils.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsUtils.kt
@@ -89,8 +89,15 @@ object CommitAIUtils {
     }
 
     fun replaceHint(promptContent: String, hint: String?): String {
-        // For now, only support the simple {hint} placeholder to avoid regex issues.
-        return promptContent.replace("{hint}", hint.orEmpty())
+        // Support {some text $hint} syntax
+        val regex = Regex("\\{(.*?)\\\$hint(.*?)}")
+        return if (hint.isNullOrBlank()) {
+            promptContent.replace(regex, "").replace("{hint}", "")
+        } else {
+            promptContent.replace(regex) {
+                it.groupValues[1] + hint + it.groupValues[2]
+            }.replace("{hint}", hint)
+        }
     }
 
     suspend fun getCommonBranch(changes: List<Change>, project: Project): String? {

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/LLMClientService.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/LLMClientService.kt
@@ -164,10 +164,18 @@ abstract class LLMClientService<C : LLMClientConfiguration>(private val cs: Coro
     }
 
     private fun cleanCommitMessage(message: String): String {
-        return message
+        var result = message.replace(Regex("<think>.*?</think>", RegexOption.DOT_MATCHES_ALL), "")
+
+        // Extract content from the first code block if it exists
+        val codeBlockRegex = Regex("```(?:\\w+)?\\s*(.*?)\\s*```", RegexOption.DOT_MATCHES_ALL)
+        val matchResult = codeBlockRegex.find(result)
+        if (matchResult != null) {
+            result = matchResult.groupValues[1]
+        }
+
+        return result
             .replace("**", "")
             .replace("```", "")
-            .replace(Regex("<think>.*?</think>", RegexOption.DOT_MATCHES_ALL), "")
             .trim()
     }
 }

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt
@@ -25,7 +25,7 @@ class PollinationsClientConfiguration : BaseRestLLMClientConfiguration(
 
     companion object {
         const val CLIENT_NAME = "Pollinations"
-        const val DEFAULT_MODEL = "openai-large"
+        const val DEFAULT_MODEL = "openai"
     }
 
     override fun getClientName(): String {

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientService.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientService.kt
@@ -25,7 +25,7 @@ class PollinationsClientService(private val cs: CoroutineScope) : LLMClientServi
         @JvmStatic
         fun getInstance(): PollinationsClientService = service()
 
-        private val seedModels = setOf("gemini", "gemini-search", PollinationsClientConfiguration.DEFAULT_MODEL)
+        private val seedModels = setOf("openai-large", "gemini", "gemini-search")
     }
 
     override suspend fun buildChatModel(client: PollinationsClientConfiguration): ChatModel {


### PR DESCRIPTION
This PR addresses several issues that might cause the plugin to fail or produce unexpected results:
1. **Pollinations Default Model**: Changed from 'openai-large' (which requires a token) to 'openai' (which is free), ensuring the plugin works immediately after installation.
2. **Conditional Hint Replacement**: Implemented the logic for `{...$hint...}` blocks. If no hint is provided, the entire block is removed, preventing confusing instructions from being sent to the AI.
3. **AI Response Cleaning**: Updated `cleanCommitMessage` to correctly handle responses from models like DeepSeek (removing `<think>` tags) and to extract the actual commit message from Markdown code blocks if the AI wraps its response in them.

---
*PR created automatically by Jules for task [4017894233075614494](https://jules.google.com/task/4017894233075614494) started by @FrancoStino*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Pollinations default model to `openai` (free) for out-of-the-box use and improves commit message parsing for cleaner, more reliable output. Also adds conditional hint blocks so unused `{...$hint...}` sections are removed.

- **Bug Fixes**
  - Default model: use `openai`; adjust seed model list; no token required.
  - Hint replacement: support `{...$hint...}`; drop block when hint is empty; `{hint}` still works.
  - Message cleaning: remove `<think>` tags; extract the first Markdown code block when present; trim and strip stray formatting.

<sup>Written for commit 1adf9ed4f0d682d4c947b93c804d8657516230da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/commit-ai-jetbrains-plugin/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes three focused improvements: it switches the Pollinations default model from `openai-large` (token-required) to `openai` (free), adds conditional `{…$hint…}` block handling in prompt construction, and extends `cleanCommitMessage` to strip DeepSeek `<think>` tags and unwrap Markdown code-block-wrapped responses.

- **Pollinations default model** (`PollinationsClientConfiguration`, `PollinationsClientService`): `DEFAULT_MODEL` is now `\"openai\"` and `seedModels` explicitly retains `\"openai-large\"` as token-required, correctly decoupling the two concerns.
- **`replaceHint`** (`AICommitsUtils`): The new `{prefix $hint suffix}` regex removes the entire block when no hint is given and expands it inline when one is provided, preserving backward compatibility with bare `{hint}`.
- **`cleanCommitMessage`** (`LLMClientService`): `<think>` tags are stripped first, then the first fenced code block is extracted; the language-specifier sub-pattern `(?:\\w+)?` is too narrow and will include unmatched specifier text in the extracted message.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the Pollinations and hint-handling changes are correct, and the two issues in cleanCommitMessage produce minor cosmetic artefacts rather than data loss.

The default-model change and seedModels adjustment are clean and well-reasoned. The replaceHint regex works correctly for single-line blocks (the common case). The two rough edges in cleanCommitMessage — an overly narrow language-specifier pattern and redundant cleaning during streaming partial responses — can produce transient visual noise or a slightly garbled extracted message in edge cases, but neither corrupts state nor loses the commit message permanently.

LLMClientService.kt deserves the most attention: the code-block extraction regex and the streaming-vs-final cleaning interaction are the areas most likely to surprise users in edge cases.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/kotlin/com/davideladisa/commitai/settings/clients/LLMClientService.kt | Adds `<think>` tag stripping and code-block extraction to `cleanCommitMessage`; the language-specifier regex is too narrow and cleaning fires on every streaming partial response, causing transient artefacts in the commit field. |
| src/main/kotlin/com/davideladisa/commitai/AICommitsUtils.kt | Extends `replaceHint` to support `{prefix $hint suffix}` block syntax with correct removal when no hint is given; regex lacks `DOT_MATCHES_ALL` so multi-line blocks are silently skipped. |
| src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt | Changes `DEFAULT_MODEL` from `"openai-large"` to `"openai"` so the plugin works out-of-the-box without a token; straightforward and correct. |
| src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientService.kt | Updates `seedModels` to hardcode `"openai-large"` so the token-required gate still applies while the new free default `"openai"` no longer requires one. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Commit UI
    participant LLM as LLMClientService
    participant AI as AI Model

    UI->>LLM: generateCommitMessage(config, handler)
    LLM->>LLM: constructPrompt
    Note over LLM: replaceHint removes blank hint blocks
    LLM->>AI: chat(prompt)

    alt Streaming mode
        loop each partial chunk
            AI-->>LLM: onPartialResponse(chunk)
            LLM->>LLM: cleanCommitMessage(accumulated)
            LLM-->>UI: setCommitMessage(partial cleaned)
        end
        AI-->>LLM: onCompleteResponse(final)
        LLM->>LLM: cleanCommitMessage(final)
        LLM-->>UI: setCommitMessage(final cleaned)
    else Non-streaming mode
        AI-->>LLM: full response
        LLM->>LLM: cleanCommitMessage(response)
        Note over LLM: Strip think tags, extract code block, strip **
        LLM-->>UI: setCommitMessage(clean)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Commit UI
    participant LLM as LLMClientService
    participant AI as AI Model

    UI->>LLM: generateCommitMessage(config, handler)
    LLM->>LLM: constructPrompt
    Note over LLM: replaceHint removes blank hint blocks
    LLM->>AI: chat(prompt)

    alt Streaming mode
        loop each partial chunk
            AI-->>LLM: onPartialResponse(chunk)
            LLM->>LLM: cleanCommitMessage(accumulated)
            LLM-->>UI: setCommitMessage(partial cleaned)
        end
        AI-->>LLM: onCompleteResponse(final)
        LLM->>LLM: cleanCommitMessage(final)
        LLM-->>UI: setCommitMessage(final cleaned)
    else Non-streaming mode
        AI-->>LLM: full response
        LLM->>LLM: cleanCommitMessage(response)
        Note over LLM: Strip think tags, extract code block, strip **
        LLM-->>UI: setCommitMessage(clean)
    end
```

</a>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22francostino%2Fcommit-ai-jetbrains-plugin%22%20on%20the%20existing%20branch%20%22fix%2Fpollinations-and-parsing-4017894233075614494%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpollinations-and-parsing-4017894233075614494%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fmain%2Fkotlin%2Fcom%2Fdavideladisa%2Fcommitai%2Fsettings%2Fclients%2FLLMClientService.kt%3A170%0AThe%20language-specifier%20portion%20of%20the%20code-block%20regex%20only%20allows%20word%20characters%20%28%60%5Cw%2B%60%29.%20If%20an%20AI%20model%20uses%20a%20multi-word%20or%20space-containing%20spec%20%28e.g.%2C%20%60git%20commit%60%29%2C%20only%20the%20first%20word%20is%20consumed%20and%20the%20remainder%20lands%20at%20the%20start%20of%20the%20captured%20commit%20message.%20For%20example%2C%20a%20response%20wrapped%20in%20%60%20%60%60%60git%20commit%20%60%20would%20have%20%60commit%0Afeat%3A%20...%60%20extracted%20as%20the%20message.%20Using%20a%20%22anything%20up%20to%20end-of-line%22%20alternative%20is%20more%20robust.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20val%20codeBlockRegex%20%3D%20Regex%28%22%60%60%60%28%3F%3A%5B%5E%5C%5Cn%5D%2B%29%3F%5C%5Cs*%28.*%3F%29%5C%5Cs*%60%60%60%22%2C%20RegexOption.DOT_MATCHES_ALL%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fmain%2Fkotlin%2Fcom%2Fdavideladisa%2Fcommitai%2Fsettings%2Fclients%2FLLMClientService.kt%3A166-180%0A**Streaming%20state%20shows%20raw%20code-fence%20artefacts**%0A%0A%60cleanCommitMessage%60%20is%20invoked%20for%20every%20partial%20chunk%20via%20%60onPartialResponse%60%20%E2%86%92%20%60onSuccess%60.%20While%20a%20code%20block%20is%20still%20accumulating%20%28no%20closing%20fence%20yet%29%2C%20%60matchResult%60%20is%20%60null%60%2C%20so%20the%20function%20falls%20through%20to%20%60.replace%28%22%60%60%60%22%2C%20%22%22%29%60%20%E2%80%94%20which%20strips%20the%20opening%20fence%20but%20leaves%20the%20language%20specifier%20literal%20%28e.g.%20%60diff%60%29%20as%20the%20visible%20commit%20message%20text.%20The%20user%20sees%20a%20flash%20of%20%60diff%5Cnfeat%3A%20partial...%60%20in%20the%20commit%20field%20until%20the%20closing%20fence%20arrives%20and%20the%20extraction%20finally%20succeeds.%20Moving%20heavy%20cleaning%20to%20a%20post-stream%20pass%20%28i.e.%20only%20on%20the%20%60completionDeferred.await%28%29%60%20path%29%20would%20eliminate%20this%20artefact.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fmain%2Fkotlin%2Fcom%2Fdavideladisa%2Fcommitai%2FAICommitsUtils.kt%3A93%0AThe%20regex%20doesn't%20include%20%60RegexOption.DOT_MATCHES_ALL%60%2C%20so%20%60.%60%20won't%20match%20newlines.%20A%20hint-block%20that%20spans%20multiple%20lines%20%28e.g.%20%60%7BPlease%20include%20this%0Amultiline%20context%3A%20%24hint%7D%60%29%20won't%20be%20matched%20and%20the%20raw%20template%20placeholder%20will%20be%20forwarded%20to%20the%20AI.%20Adding%20%60DOT_MATCHES_ALL%60%20ensures%20the%20pattern%20works%20for%20multi-line%20blocks%20as%20well.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20val%20regex%20%3D%20Regex%28%22%5C%5C%7B%28.*%3F%29%5C%5C%5C%24hint%28.*%3F%29%7D%22%2C%20RegexOption.DOT_MATCHES_ALL%29%0A%60%60%60%0A%0A&repo=francostino%2Fcommit-ai-jetbrains-plugin&tid=70573&ts=1782592093&sig=02e2fc7a1b099fef64d8fc2ada0f8b032ad7f124245f91ea7005996930aa0fdf&pr=119&platform=github&fid=d35e03ae-a993-4adf-83da-9a7ac9a94ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: improve Pollinations default and co..."](https://github.com/francostino/commit-ai-jetbrains-plugin/commit/1adf9ed4f0d682d4c947b93c804d8657516230da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40305814)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->