### PR TITLE
Risoluzione problemi di generazione messaggi e integrazione Pollinations AI

### DIFF
--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsUtils.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsUtils.kt
@@ -89,8 +89,20 @@ object CommitAIUtils {
     }
 
     fun replaceHint(promptContent: String, hint: String?): String {
+        var content = promptContent
+        // Support conditional replacement: {This is a $hint}
+        // If hint is blank, the entire block is removed.
+        val regex = Regex("\\{([^}]*\\\$hint[^}]*)\\}")
+        content = regex.replace(content) { matchResult ->
+            if (hint.isNullOrBlank()) {
+                ""
+            } else {
+                matchResult.groupValues[1].replace("\$hint", hint)
+            }
+        }
+
         // For now, only support the simple {hint} placeholder to avoid regex issues.
-        return promptContent.replace("{hint}", hint.orEmpty())
+        return content.replace("{hint}", hint.orEmpty())
     }
 
     suspend fun getCommonBranch(changes: List<Change>, project: Project): String? {

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/LLMClientService.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/LLMClientService.kt
@@ -57,16 +57,23 @@ abstract class LLMClientService<C : LLMClientConfiguration>(private val cs: Coro
                 val branch = getCommonBranch(includedChanges, project)
                 val prompt = constructPrompt(project.service<ProjectSettings>().activePrompt.content, diff, branch, commitWorkflowHandler.getCommitMessage(), project)
 
-                makeRequest(clientConfiguration, prompt, onSuccess = {
-                    withContext(Dispatchers.EDT) {
-                        clientConfiguration.setCommitMessage(commitWorkflowHandler, prompt, cleanCommitMessage(it))
+                makeRequest(
+                    clientConfiguration,
+                    prompt,
+                    onSuccess = {
+                        withContext(Dispatchers.EDT) {
+                            clientConfiguration.setCommitMessage(commitWorkflowHandler, prompt, cleanCommitMessage(it))
+                        }
+                    },
+                    onComplete = {
+                        AppSettings2.instance.recordHit()
+                    },
+                    onError = {
+                        withContext(Dispatchers.EDT) {
+                            commitWorkflowHandler.setCommitMessage(it)
+                        }
                     }
-                    AppSettings2.instance.recordHit()
-                }, onError = {
-                    withContext(Dispatchers.EDT) {
-                        commitWorkflowHandler.setCommitMessage(it)
-                    }
-                })
+                )
             }
         }
     }
@@ -101,19 +108,33 @@ abstract class LLMClientService<C : LLMClientConfiguration>(private val cs: Coro
         }
     }
 
-    private suspend fun makeRequest(client: C, text: String, onSuccess: suspend (r: String) -> Unit, onError: suspend (r: String) -> Unit) {
+    private suspend fun makeRequest(
+        client: C,
+        text: String,
+        onSuccess: suspend (r: String) -> Unit,
+        onComplete: suspend (r: String) -> Unit = {},
+        onError: suspend (r: String) -> Unit
+    ) {
         makeRequestWithTryCatch(function = {
             if (AppSettings2.instance.useStreamingResponse) {
                 buildStreamingChatModel(client)?.let { streamingChatModel ->
-                    sendStreamingRequest(streamingChatModel, text, onSuccess)
+                    sendStreamingRequest(streamingChatModel, text, onSuccess, onComplete)
                     return@makeRequestWithTryCatch
                 }
             }
-            sendRequest(client, text, onSuccess)
+            sendRequest(client, text, {
+                onSuccess(it)
+                onComplete(it)
+            })
         }, onError = onError)
     }
 
-    private suspend fun sendStreamingRequest(streamingModel: StreamingChatModel, text: String, onSuccess: suspend (r: String) -> Unit) {
+    private suspend fun sendStreamingRequest(
+        streamingModel: StreamingChatModel,
+        text: String,
+        onSuccess: suspend (r: String) -> Unit,
+        onComplete: suspend (r: String) -> Unit
+    ) {
         var response = ""
         val completionDeferred = CompletableDeferred<String>()
 
@@ -144,7 +165,9 @@ abstract class LLMClientService<C : LLMClientConfiguration>(private val cs: Coro
             )
             // This throws exception if completionDeferred.completeExceptionally(error) is called
             // which is handled by the function calling this function
-            onSuccess(completionDeferred.await())
+            val finalResponse = completionDeferred.await()
+            onSuccess(finalResponse)
+            onComplete(finalResponse)
         }
     }
 
@@ -164,10 +187,17 @@ abstract class LLMClientService<C : LLMClientConfiguration>(private val cs: Coro
     }
 
     private fun cleanCommitMessage(message: String): String {
-        return message
+        var content = message.replace(Regex("<think>.*?</think>", RegexOption.DOT_MATCHES_ALL), "").trim()
+
+        // Extract content from the first markdown code block if present
+        val codeBlockRegex = Regex("```(?:[a-zA-Z]*\\n)?([\\s\\S]*?)```")
+        codeBlockRegex.find(content)?.let {
+            content = it.groupValues[1].trim()
+        }
+
+        return content
             .replace("**", "")
             .replace("```", "")
-            .replace(Regex("<think>.*?</think>", RegexOption.DOT_MATCHES_ALL), "")
             .trim()
     }
 }

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt
@@ -25,7 +25,7 @@ class PollinationsClientConfiguration : BaseRestLLMClientConfiguration(
 
     companion object {
         const val CLIENT_NAME = "Pollinations"
-        const val DEFAULT_MODEL = "openai-large"
+        const val DEFAULT_MODEL = "openai"
     }
 
     override fun getClientName(): String {

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientService.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientService.kt
@@ -25,7 +25,7 @@ class PollinationsClientService(private val cs: CoroutineScope) : LLMClientServi
         @JvmStatic
         fun getInstance(): PollinationsClientService = service()
 
-        private val seedModels = setOf("gemini", "gemini-search", PollinationsClientConfiguration.DEFAULT_MODEL)
+        private val seedModels = setOf("gemini", "gemini-search", "openai-large")
     }
 
     override suspend fun buildChatModel(client: PollinationsClientConfiguration): ChatModel {


### PR DESCRIPTION
Ho corretto diversi problemi che impedivano al plugin di funzionare correttamente:

1. **Modello Pollinations**: Ho impostato 'openai' come modello predefinito invece di 'openai-large', poiché il primo è gratuito e non richiede un token API. Ho anche aggiornato la logica dei requisiti del token.
2. **Logica degli Hint**: Ho implementato correttamente la sintassi condizionale `{...$hint...}` nei prompt. Se l'hint è vuoto, l'intero blocco viene rimosso; altrimenti, `$hint` viene sostituito con il valore reale.
3. **Pulizia dei Messaggi**: Ho migliorato l'estrazione dei messaggi dell'IA. Ora il plugin è in grado di estrarre il contenuto dai blocchi di codice Markdown e rimuove correttamente i tag `<think>` (usati da modelli come DeepSeek).
4. **Statistiche d'uso**: Ho corretto un bug per cui, durante lo streaming, venivano registrate molteplici "hit". Ora la statistica viene incrementata solo al completamento della generazione.

Queste modifiche dovrebbero risolvere i problemi di generazione dei messaggi di commit.

---
*PR created automatically by Jules for task [10738112168105540357](https://jules.google.com/task/10738112168105540357) started by @FrancoStino*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes commit message generation and Pollinations setup so it works reliably out of the box. Improves hint handling, cleans model outputs, and records usage stats correctly.

- **Bug Fixes**
  - Set Pollinations default model to `openai` and updated token rules so `openai` requires no API token.
  - Implemented conditional hint blocks `{...$hint...}`: remove block if hint is empty; otherwise replace `$hint`. Still supports `{hint}`.
  - Cleaned generated messages: extract text from the first Markdown code block, remove `<think>` tags, and strip leftover formatting.
  - Recorded usage stats only once after completion (including streaming).

<sup>Written for commit a26ecc1a5ca8945f9d6e100bc9499a20470362a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/commit-ai-jetbrains-plugin/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four issues in the Pollinations AI integration: the default model is changed from `openai-large` to `openai` (free, no token required), conditional hint blocks `{...$hint...}` are now correctly stripped when the hint is empty, `<think>` tag removal and markdown code-block extraction are added to `cleanCommitMessage`, and `recordHit()` is moved to a new `onComplete` callback so it fires once per generation instead of once per streaming chunk.

- The `onComplete` callback fix and the `seedModels` hardcoding are correct and well-scoped.
- `replaceHint` is backward-compatible with existing `{hint}` templates while adding the new conditional syntax.
- `cleanCommitMessage`'s code-block extraction has a logic flaw: if the AI response contains the commit message as plain text and a code snippet only as a supplementary example, the extractor replaces the actual message with the code snippet.

<h3>Confidence Score: 3/5</h3>

The streaming hit-count fix and the Pollinations default model change are safe to merge, but the code-block extraction in cleanCommitMessage can overwrite a valid commit message with a code snippet when the AI response contains supplementary code examples.

Three of the four fixes are correct. The cleanCommitMessage rewrite introduces a scenario where the plugin silently produces a wrong commit message — replacing the actual commit text with a code snippet from within the AI response — whenever the model includes code examples alongside the message. This is a functional regression on a core user-facing path.

LLMClientService.kt — specifically the cleanCommitMessage code-block extraction logic and the onComplete callback signature.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/main/kotlin/com/davideladisa/commitai/settings/clients/LLMClientService.kt | Moves `recordHit()` to a new `onComplete` callback fired once after completion (good fix), but the `cleanCommitMessage` overhaul has a logic flaw: it unconditionally replaces all content with the first code block found, which produces a wrong commit message when the AI appends a code example after the actual message text. |
| src/main/kotlin/com/davideladisa/commitai/AICommitsUtils.kt | Adds conditional `{...$hint...}` block removal when hint is blank; backward-compatible with existing `{hint}` templates and the implementation is correct. |
| src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt | Changes DEFAULT_MODEL from `openai-large` to `openai` so the free, no-token model is used by default; straightforward and correct. |
| src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientService.kt | Hardcodes `openai-large` in seedModels instead of referencing DEFAULT_MODEL; correctly preserves the token requirement for the large model after the default model changed. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Commit UI
    participant LLM as LLMClientService
    participant Model as StreamingChatModel
    participant EDT as EDT Thread
    participant Stats as AppSettings2

    UI->>LLM: generateCommitMessage()
    LLM->>LLM: buildPrompt / cleanDiff

    alt Streaming enabled
        LLM->>Model: chat(prompt, handler)
        loop partial tokens
            Model-->>LLM: onPartialResponse(token)
            LLM->>LLM: "response += token"
            LLM-->>EDT: cs.launch → onSuccess(response) → setCommitMessage(partial)
        end
        Model-->>LLM: onCompleteResponse(finalText)
        LLM->>LLM: completionDeferred.complete(finalText)
        LLM->>EDT: onSuccess(finalResponse) → setCommitMessage(clean)
        LLM->>Stats: onComplete() → recordHit() [once only]
    else Non-streaming
        LLM->>Model: chat(prompt)
        Model-->>LLM: response text
        LLM->>EDT: onSuccess(response) → setCommitMessage(clean)
        LLM->>Stats: onComplete() → recordHit() [once only]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Commit UI
    participant LLM as LLMClientService
    participant Model as StreamingChatModel
    participant EDT as EDT Thread
    participant Stats as AppSettings2

    UI->>LLM: generateCommitMessage()
    LLM->>LLM: buildPrompt / cleanDiff

    alt Streaming enabled
        LLM->>Model: chat(prompt, handler)
        loop partial tokens
            Model-->>LLM: onPartialResponse(token)
            LLM->>LLM: "response += token"
            LLM-->>EDT: cs.launch → onSuccess(response) → setCommitMessage(partial)
        end
        Model-->>LLM: onCompleteResponse(finalText)
        LLM->>LLM: completionDeferred.complete(finalText)
        LLM->>EDT: onSuccess(finalResponse) → setCommitMessage(clean)
        LLM->>Stats: onComplete() → recordHit() [once only]
    else Non-streaming
        LLM->>Model: chat(prompt)
        Model-->>LLM: response text
        LLM->>EDT: onSuccess(response) → setCommitMessage(clean)
        LLM->>Stats: onComplete() → recordHit() [once only]
    end
```

</a>

<a href="https://app.greptile.com/api/ide/devin?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22francostino%2Fcommit-ai-jetbrains-plugin%22%20on%20the%20existing%20branch%20%22fix-generation-issues-10738112168105540357%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-generation-issues-10738112168105540357%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fmain%2Fkotlin%2Fcom%2Fdavideladisa%2Fcommitai%2Fsettings%2Fclients%2FLLMClientService.kt%3A192-201%0A**Code-block%20extraction%20discards%20the%20commit%20message%20when%20AI%20adds%20a%20code%20example**%0A%0A%60codeBlockRegex.find%28content%29%60%20greedily%20takes%20the%20*first*%20markdown%20code%20block%20it%20encounters%20and%20replaces%20the%20*entire*%20%60content%60%20with%20its%20inner%20text.%20If%20the%20model%20responds%20with%20the%20commit%20message%20as%20plain%20text%20and%20then%20includes%20a%20code%20snippet%20to%20illustrate%20the%20change%2C%20the%20function%20discards%20the%20actual%20commit%20message%20and%20returns%20the%20code%20snippet%20instead.%20The%20intent%20is%20to%20handle%20models%20that%20wrap%20the%20whole%20commit%20message%20in%20a%20fenced%20block%2C%20but%20the%20current%20unconditional%20replacement%20breaks%20responses%20where%20the%20commit%20message%20is%20plain%20text%20and%20a%20code%20block%20only%20appears%20as%20supplementary%20content.%20A%20safer%20heuristic%20would%20be%20to%20only%20extract%20from%20the%20code%20block%20when%20%60content%60%20contains%20no%20substantial%20text%20outside%20the%20block.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fmain%2Fkotlin%2Fcom%2Fdavideladisa%2Fcommitai%2Fsettings%2Fclients%2FLLMClientService.kt%3A111-117%0AThe%20%60onComplete%60%20callback%20is%20declared%20as%20%60suspend%20%28r%3A%20String%29%20-%3E%20Unit%60%20but%20every%20caller%20ignores%20the%20%60String%60%20argument%20%28the%20only%20call%20site%20uses%20%60%7B%20AppSettings2.instance.recordHit%28%29%20%7D%60%29.%20The%20unused%20parameter%20leaks%20implementation%20details%20and%20forces%20downstream%20callers%20to%20accept%20a%20string%20they'll%20never%20use.%20Changing%20it%20to%20%60suspend%20%28%29%20-%3E%20Unit%60%20cleans%20this%20up.%0A%0A%60%60%60suggestion%0A%20%20%20%20private%20suspend%20fun%20makeRequest%28%0A%20%20%20%20%20%20%20%20client%3A%20C%2C%0A%20%20%20%20%20%20%20%20text%3A%20String%2C%0A%20%20%20%20%20%20%20%20onSuccess%3A%20suspend%20%28r%3A%20String%29%20-%3E%20Unit%2C%0A%20%20%20%20%20%20%20%20onComplete%3A%20suspend%20%28%29%20-%3E%20Unit%20%3D%20%7B%7D%2C%0A%20%20%20%20%20%20%20%20onError%3A%20suspend%20%28r%3A%20String%29%20-%3E%20Unit%0A%20%20%20%20%29%20%7B%0A%60%60%60%0A%0A&repo=francostino%2Fcommit-ai-jetbrains-plugin&tid=70573&ts=1782678308&sig=d8db1e50725855cf1915b32a884c9ad813f5d833c214c710f60aabf6622cd950&pr=120&platform=github&fid=b4b57fa1-ed2c-4cf5-87e1-1fbfe7117519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevinDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3"><img alt="Fix All in Devin" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInDevin.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix several issues with commit message g..."](https://github.com/francostino/commit-ai-jetbrains-plugin/commit/a26ecc1a5ca8945f9d6e100bc9499a20470362a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40391569)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->