### PR TITLE
Fix AI commit generation and cleaning logic

### DIFF
--- a/src/main/kotlin/com/davideladisa/commitai/AICommitsUtils.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/AICommitsUtils.kt
@@ -89,8 +89,15 @@ object CommitAIUtils {
     }
 
     fun replaceHint(promptContent: String, hint: String?): String {
-        // For now, only support the simple {hint} placeholder to avoid regex issues.
-        return promptContent.replace("{hint}", hint.orEmpty())
+        val regex = Regex("\\{([^}]*\\\$hint[^}]*)\\}")
+        val result = if (hint.isNullOrBlank()) {
+            promptContent.replace(regex, "")
+        } else {
+            promptContent.replace(regex) { matchResult ->
+                matchResult.groupValues[1].replace("\$hint", hint)
+            }
+        }
+        return result.replace("{hint}", hint.orEmpty())
     }
 
     suspend fun getCommonBranch(changes: List<Change>, project: Project): String? {

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/LLMClientService.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/LLMClientService.kt
@@ -164,10 +164,15 @@ abstract class LLMClientService<C : LLMClientConfiguration>(private val cs: Coro
     }
 
     private fun cleanCommitMessage(message: String): String {
-        return message
+        val cleaned = message.replace(Regex("<think>.*?</think>", RegexOption.DOT_MATCHES_ALL), "").trim()
+
+        val codeBlockRegex = Regex("```(?:[\\w-]*\\n)?([\\s\\S]*?)```")
+        val matchResult = codeBlockRegex.find(cleaned)
+        val extracted = matchResult?.groupValues?.get(1)?.trim() ?: cleaned
+
+        return extracted
             .replace("**", "")
             .replace("```", "")
-            .replace(Regex("<think>.*?</think>", RegexOption.DOT_MATCHES_ALL), "")
             .trim()
     }
 }

--- a/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt
+++ b/src/main/kotlin/com/davideladisa/commitai/settings/clients/pollinations/PollinationsClientConfiguration.kt
@@ -25,7 +25,7 @@ class PollinationsClientConfiguration : BaseRestLLMClientConfiguration(
 
     companion object {
         const val CLIENT_NAME = "Pollinations"
-        const val DEFAULT_MODEL = "openai-large"
+        const val DEFAULT_MODEL = "openai"
     }
 
     override fun getClientName(): String {


### PR DESCRIPTION
This PR addresses several issues that were causing the AI commit message generation to fail or produce poorly formatted results.

1. **Conditional Hint Logic**: The `{...$hint...}` syntax in prompts now correctly removes the entire block if the hint is blank, preventing raw template strings from being sent to the LLM.
2. **Pollinations Default Model**: Changed the default model to `openai`, which is the standard free model, avoiding "Token is required" errors for new users.
3. **Response Cleaning**: The plugin now extracts commit messages from Markdown code blocks and removes `<think>` reasoning tags, ensuring only the intended commit message is populated in the IDE.

---
*PR created automatically by Jules for task [8044614684808296881](https://jules.google.com/task/8044614684808296881) started by @FrancoStino*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes commit message generation and formatting by properly handling optional hints, switching the Pollinations default model to `openai`, and extracting clean commit text from responses.

- **Bug Fixes**
  - Remove `{...$hint...}` blocks when the hint is blank; keep `{hint}` replacement when provided.
  - Extract commit text from fenced code blocks and strip `<think>` tags and markdown markers.
  - Set Pollinations default model to `openai` to prevent token errors for new users.

<sup>Written for commit 269d45d7918e06057ca3c00063eb2a0716234191. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/commit-ai-jetbrains-plugin/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

