### PR TITLE
Bump Gradle wrapper and key dependency versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.5.0"
-intelliJPlatform = "2.16.0"
+intelliJPlatform = "2.17.0"
 kotlin = "2.4.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ opentest4j = "1.3.0"
 
 # plugins
 changelog = "2.5.0"
-intelliJPlatform = "2.17.0"
+intelliJPlatform = "2.18.1"
 kotlin = "2.4.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 junit = "4.13.2"
-langchain4j = "1.16.3"
+langchain4j = "1.17.0"
 opentest4j = "1.3.0"
 
 # plugins

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 junit = "4.13.2"
-langchain4j = "1.17.0"
+langchain4j = "1.17.2"
 opentest4j = "1.3.0"
 
 # plugins

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=bbaeb2fef8710818cf0e261201dab964c572f92b942812df0c3620d62a529a01
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=3
 retryBackOffMs=500


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates build tooling and key libraries to improve stability and keep dependencies current. Bumps Gradle to 9.6.1, `org.jetbrains.intellij.platform` to 2.18.1, and `langchain4j` to 1.17.2.

- **Dependencies**
  - Gradle wrapper: 9.6.0 → 9.6.1 (updated checksum)
  - `org.jetbrains.intellij.platform`: 2.16.0 → 2.18.1
  - `langchain4j`: 1.16.3 → 1.17.2

<sup>Written for commit ee291052616e2e3ca7a16329908467ea61552dc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrancoStino/commit-ai-jetbrains-plugin/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the project's build and dependency versions. The main changes are:

- LangChain4j is bumped to 1.17.2.
- The IntelliJ Platform Gradle Plugin is bumped to 2.18.1.
- The Gradle wrapper is bumped to 9.6.1 with a new distribution checksum.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| gradle/libs.versions.toml | Updates LangChain4j and the IntelliJ Platform Gradle Plugin version declarations. |
| gradle/wrapper/gradle-wrapper.properties | Updates the Gradle wrapper distribution URL and checksum for 9.6.1. |

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #126 from FrancoStino..."](https://github.com/francostino/commit-ai-jetbrains-plugin/commit/ee291052616e2e3ca7a16329908467ea61552dc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44065376)</sub>

<!-- /greptile_comment -->